### PR TITLE
Fix jdk8 add metrics remove provided from ear

### DIFF
--- a/deploy-weblogic/pom.xml
+++ b/deploy-weblogic/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>eu.europa.ec.fisheries.uvms.reporting</groupId>
         <artifactId>reporting</artifactId>
-        <version>1.0.3-SNAPSHOT</version>
+        <version>1.0.3</version>
     </parent>
 
     <properties>

--- a/deploy-weblogic/pom.xml
+++ b/deploy-weblogic/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>eu.europa.ec.fisheries.uvms.reporting</groupId>
         <artifactId>reporting</artifactId>
-        <version>1.0.4</version>
+        <version>1.0.5-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/deploy-weblogic/pom.xml
+++ b/deploy-weblogic/pom.xml
@@ -62,7 +62,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-ear-plugin</artifactId>
-                <version>2.7</version>
                 <configuration>
                     <defaultLibBundleDir>APP-INF/lib</defaultLibBundleDir>
                     <skinnyWars>true</skinnyWars>
@@ -100,6 +99,7 @@
                             <bundleDir>/</bundleDir>
                         </jarModule>
                     </modules>
+                    <version>7</version>
                 </configuration>
             </plugin>
         </plugins>

--- a/deploy-weblogic/pom.xml
+++ b/deploy-weblogic/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>eu.europa.ec.fisheries.uvms.reporting</groupId>
         <artifactId>reporting</artifactId>
-        <version>1.0.4-SNAPSHOT</version>
+        <version>1.0.4</version>
     </parent>
 
     <properties>

--- a/deploy-weblogic/pom.xml
+++ b/deploy-weblogic/pom.xml
@@ -99,7 +99,6 @@
                             <bundleDir>/</bundleDir>
                         </jarModule>
                     </modules>
-                    <version>7</version>
                 </configuration>
             </plugin>
         </plugins>

--- a/deploy-weblogic/pom.xml
+++ b/deploy-weblogic/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>eu.europa.ec.fisheries.uvms.reporting</groupId>
         <artifactId>reporting</artifactId>
-        <version>1.0.3</version>
+        <version>1.0.4-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/deploy-wildfly/pom.xml
+++ b/deploy-wildfly/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>eu.europa.ec.fisheries.uvms.reporting</groupId>
         <artifactId>reporting</artifactId>
-        <version>1.0.3</version>
+        <version>1.0.4-SNAPSHOT</version>
     </parent>
 
     <build>

--- a/deploy-wildfly/pom.xml
+++ b/deploy-wildfly/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>eu.europa.ec.fisheries.uvms.reporting</groupId>
         <artifactId>reporting</artifactId>
-        <version>1.0.4</version>
+        <version>1.0.5-SNAPSHOT</version>
     </parent>
 
     <build>

--- a/deploy-wildfly/pom.xml
+++ b/deploy-wildfly/pom.xml
@@ -40,7 +40,6 @@
                         </webModule>
                     </modules>
                     <skinnyWars>true</skinnyWars>
-                    <version>7</version>
                 </configuration>
             </plugin>
             <plugin>

--- a/deploy-wildfly/pom.xml
+++ b/deploy-wildfly/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>eu.europa.ec.fisheries.uvms.reporting</groupId>
         <artifactId>reporting</artifactId>
-        <version>1.0.4-SNAPSHOT</version>
+        <version>1.0.4</version>
     </parent>
 
     <build>

--- a/deploy-wildfly/pom.xml
+++ b/deploy-wildfly/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>eu.europa.ec.fisheries.uvms.reporting</groupId>
         <artifactId>reporting</artifactId>
-        <version>1.0.3-SNAPSHOT</version>
+        <version>1.0.3</version>
     </parent>
 
     <build>

--- a/deploy-wildfly/pom.xml
+++ b/deploy-wildfly/pom.xml
@@ -19,7 +19,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-ear-plugin</artifactId>
-                <version>2.7</version>
                 <configuration>
                     <modules>
                         <ejbModule>
@@ -41,6 +40,7 @@
                         </webModule>
                     </modules>
                     <skinnyWars>true</skinnyWars>
+                    <version>7</version>
                 </configuration>
             </plugin>
             <plugin>

--- a/message/pom.xml
+++ b/message/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>eu.europa.ec.fisheries.uvms.reporting</groupId>
         <artifactId>reporting</artifactId>
-        <version>1.0.4-SNAPSHOT</version>
+        <version>1.0.4</version>
     </parent>
     
     <dependencies>

--- a/message/pom.xml
+++ b/message/pom.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>message</artifactId>
@@ -10,7 +9,7 @@
     <parent>
         <groupId>eu.europa.ec.fisheries.uvms.reporting</groupId>
         <artifactId>reporting</artifactId>
-        <version>1.0.3-SNAPSHOT</version>
+        <version>1.0.3</version>
     </parent>
     
     <dependencies>

--- a/message/pom.xml
+++ b/message/pom.xml
@@ -43,6 +43,12 @@
         </dependency>
 
         <dependency>
+			<groupId>fish.focus.uvms.maven</groupId>
+			<artifactId>uvms-pom-monitoring-deps</artifactId>
+			<type>pom</type>
+		</dependency>
+
+        <dependency>
             <groupId>eu.europa.ec.fisheries.uvms</groupId>
             <artifactId>uvms-commons</artifactId>
         </dependency>

--- a/message/pom.xml
+++ b/message/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>eu.europa.ec.fisheries.uvms.reporting</groupId>
         <artifactId>reporting</artifactId>
-        <version>1.0.3</version>
+        <version>1.0.4-SNAPSHOT</version>
     </parent>
     
     <dependencies>

--- a/message/pom.xml
+++ b/message/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>eu.europa.ec.fisheries.uvms.reporting</groupId>
         <artifactId>reporting</artifactId>
-        <version>1.0.4</version>
+        <version>1.0.5-SNAPSHOT</version>
     </parent>
     
     <dependencies>

--- a/message/pom.xml
+++ b/message/pom.xml
@@ -83,7 +83,7 @@
         <dependency>
             <groupId>eu.europa.ec.fisheries.uvms.movement</groupId>
             <artifactId>movement-model</artifactId>
-			<classifier>xmlgregoriancalendar</classifier>
+			<classifier>date</classifier>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -36,11 +36,11 @@
         <application.version>${project.parent.version}</application.version>
         <application.logfile>/app/logs/${project.parent.artifactId}/${project.parent.artifactId}.log</application.logfile>
         <application.error.logfile>/app/logs/${project.parent.artifactId}/${project.parent.artifactId}-error.log</application.error.logfile>
-        <hibernate.version>4.3.10.Final</hibernate.version>
-        <uvms.commons.version>2.0.25</uvms.commons.version>
-        <geotools.version>14-M1</geotools.version>
-        <lombok.version>1.16.4</lombok.version>
-        <usm4uvms.version>3.0.6</usm4uvms.version>
+        <hibernate.version>4.3.11.Final</hibernate.version>
+        <uvms.commons.version>2.0.27</uvms.commons.version>
+        <geotools.version>14.4</geotools.version>
+        <lombok.version>1.16.18</lombok.version>
+        <usm4uvms.version>3.0.8</usm4uvms.version>
         <maven.release.plugin.version>2.5.3</maven.release.plugin.version>
         <maven.scm.provider.version>2.1.1</maven.scm.provider.version>
         <rules.model.version>3.0.7</rules.model.version>
@@ -72,6 +72,13 @@
     <dependencyManagement>
 
         <dependencies>
+
+			<dependency>
+				<groupId>fish.focus.uvms.maven</groupId>
+				<artifactId>uvms-pom-monitoring-deps</artifactId>
+				<version>1.8</version>
+				<type>pom</type>
+			</dependency>
 
             <dependency>
                 <groupId>eu.europa.ec.fisheries.uvms.activity</groupId>
@@ -239,13 +246,13 @@
             <dependency>
                 <groupId>org.projectlombok</groupId>
                 <artifactId>lombok</artifactId>
-                <version>1.16.4</version>
+                <version>1.16.18</version>
             </dependency>
 
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>18.0</version>
+                <version>20.0</version>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
         <uvms.commons.version>2.0.18-SNAPSHOT</uvms.commons.version>
         <geotools.version>14-M1</geotools.version>
         <lombok.version>1.16.4</lombok.version>
-        <usm4uvms.version>2.0.19</usm4uvms.version>
+        <usm4uvms.version>3.0.6-SNAPSHOT</usm4uvms.version>
         <maven.release.plugin.version>2.5.2</maven.release.plugin.version>
         <maven.scm.provider.version>2.1.1</maven.scm.provider.version>
         <rules.model.version>3.0.0</rules.model.version>

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <application.logfile>/app/logs/${project.parent.artifactId}/${project.parent.artifactId}.log</application.logfile>
         <application.error.logfile>/app/logs/${project.parent.artifactId}/${project.parent.artifactId}-error.log</application.error.logfile>
         <hibernate.version>4.3.10.Final</hibernate.version>
-        <uvms.commons.version>2.0.18-SNAPSHOT</uvms.commons.version>
+        <uvms.commons.version>2.0.21</uvms.commons.version>
         <geotools.version>14-M1</geotools.version>
         <lombok.version>1.16.4</lombok.version>
         <usm4uvms.version>3.0.6</usm4uvms.version>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>eu.europa.ec.fisheries.uvms.reporting</groupId>
     <artifactId>reporting</artifactId>
-    <version>1.0.4-SNAPSHOT</version>
+    <version>1.0.4</version>
     <packaging>pom</packaging>
     <description>Maven projekt-archetype for UnionVms modules</description>
     <url>http://www.your.site.com/</url>
@@ -53,7 +53,7 @@
 
     <scm>
         <connection>${scm.connection}</connection>
-        <tag>HEAD</tag>
+        <tag>reporting-1.0.4</tag>
     </scm>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <asset.model.version>3.0.0</asset.model.version>
         <audit.model.version>3.0.0</audit.model.version>
         <movement.model.version>3.0.4</movement.model.version>
-        <spatial.model.version>1.0.3</spatial.model.version>
+        <spatial.model.version>1.0.5-SNAPSHOT</spatial.model.version>
         <application.name>${project.parent.artifactId}</application.name>
         <application.version>${project.parent.version}</application.version>
         <application.logfile>/app/logs/${project.parent.artifactId}/${project.parent.artifactId}.log</application.logfile>
@@ -39,7 +39,7 @@
         <maven.release.plugin.version>2.5.2</maven.release.plugin.version>
         <maven.scm.provider.version>2.1.1</maven.scm.provider.version>
         <rules.model.version>3.0.0</rules.model.version>
-		<reporting.model.version>1.0.2</reporting.model.version>
+		<reporting.model.version>1.0.3-SNAPSHOT</reporting.model.version>
         <uvms.test.version>0.0.4</uvms.test.version>
         <activity.model.version>0.5.12-SNAPSHOT</activity.model.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -2,6 +2,12 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
+	<parent>
+		<groupId>fish.focus.uvms.maven</groupId>
+		<artifactId>uvms-pom</artifactId>
+		<version>1.8</version>
+	</parent>
+
     <groupId>eu.europa.ec.fisheries.uvms.reporting</groupId>
     <artifactId>reporting</artifactId>
     <version>1.0.4-SNAPSHOT</version>
@@ -22,22 +28,22 @@
         <mapstruct.version>1.1.0.Final</mapstruct.version>
         <jackson.version>2.7.3</jackson.version>
         <logback.core.version>1.1.2</logback.core.version>
-        <asset.model.version>3.0.0</asset.model.version>
-        <audit.model.version>3.0.0</audit.model.version>
-        <movement.model.version>3.0.4</movement.model.version>
+        <asset.model.version>3.0.4</asset.model.version>
+        <audit.model.version>3.0.4</audit.model.version>
+        <movement.model.version>3.0.6</movement.model.version>
         <spatial.model.version>1.0.5</spatial.model.version>
         <application.name>${project.parent.artifactId}</application.name>
         <application.version>${project.parent.version}</application.version>
         <application.logfile>/app/logs/${project.parent.artifactId}/${project.parent.artifactId}.log</application.logfile>
         <application.error.logfile>/app/logs/${project.parent.artifactId}/${project.parent.artifactId}-error.log</application.error.logfile>
         <hibernate.version>4.3.10.Final</hibernate.version>
-        <uvms.commons.version>2.0.21</uvms.commons.version>
+        <uvms.commons.version>2.0.25</uvms.commons.version>
         <geotools.version>14-M1</geotools.version>
         <lombok.version>1.16.4</lombok.version>
         <usm4uvms.version>3.0.6</usm4uvms.version>
-        <maven.release.plugin.version>2.5.2</maven.release.plugin.version>
+        <maven.release.plugin.version>2.5.3</maven.release.plugin.version>
         <maven.scm.provider.version>2.1.1</maven.scm.provider.version>
-        <rules.model.version>3.0.0</rules.model.version>
+        <rules.model.version>3.0.7</rules.model.version>
 		<reporting.model.version>1.0.3</reporting.model.version>
         <uvms.test.version>0.0.4</uvms.test.version>
         <activity.model.version>0.5.12</activity.model.version>
@@ -135,7 +141,7 @@
                 <groupId>eu.europa.ec.fisheries.uvms.movement</groupId>
                 <artifactId>movement-model</artifactId>
                 <version>${movement.model.version}</version>
-                <classifier>xmlgregoriancalendar</classifier>
+                <classifier>date</classifier>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>eu.europa.ec.fisheries.uvms.reporting</groupId>
     <artifactId>reporting</artifactId>
-    <version>1.0.4</version>
+    <version>1.0.5-SNAPSHOT</version>
     <packaging>pom</packaging>
     <description>Maven projekt-archetype for UnionVms modules</description>
     <url>http://www.your.site.com/</url>
@@ -53,7 +53,7 @@
 
     <scm>
         <connection>${scm.connection}</connection>
-        <tag>reporting-1.0.4</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>eu.europa.ec.fisheries.uvms.reporting</groupId>
     <artifactId>reporting</artifactId>
-    <version>1.0.3</version>
+    <version>1.0.4-SNAPSHOT</version>
     <packaging>pom</packaging>
     <description>Maven projekt-archetype for UnionVms modules</description>
     <url>http://www.your.site.com/</url>
@@ -47,7 +47,7 @@
 
     <scm>
         <connection>${scm.connection}</connection>
-        <tag>reporting-1.0.3</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <asset.model.version>3.0.0</asset.model.version>
         <audit.model.version>3.0.0</audit.model.version>
         <movement.model.version>3.0.4</movement.model.version>
-        <spatial.model.version>1.0.5-SNAPSHOT</spatial.model.version>
+        <spatial.model.version>1.0.5</spatial.model.version>
         <application.name>${project.parent.artifactId}</application.name>
         <application.version>${project.parent.version}</application.version>
         <application.logfile>/app/logs/${project.parent.artifactId}/${project.parent.artifactId}.log</application.logfile>
@@ -35,13 +35,13 @@
         <uvms.commons.version>2.0.18-SNAPSHOT</uvms.commons.version>
         <geotools.version>14-M1</geotools.version>
         <lombok.version>1.16.4</lombok.version>
-        <usm4uvms.version>3.0.6-SNAPSHOT</usm4uvms.version>
+        <usm4uvms.version>3.0.6</usm4uvms.version>
         <maven.release.plugin.version>2.5.2</maven.release.plugin.version>
         <maven.scm.provider.version>2.1.1</maven.scm.provider.version>
         <rules.model.version>3.0.0</rules.model.version>
-		<reporting.model.version>1.0.3-SNAPSHOT</reporting.model.version>
+		<reporting.model.version>1.0.3</reporting.model.version>
         <uvms.test.version>0.0.4</uvms.test.version>
-        <activity.model.version>0.5.12-SNAPSHOT</activity.model.version>
+        <activity.model.version>0.5.12</activity.model.version>
 
         <scm.connection>scm:git:https://github.com/UnionVMS/UVMS-ReportingModule-APP.git</scm.connection>
     </properties>
@@ -447,17 +447,13 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
                 <version>${maven.release.plugin.version}</version>
-                <dependencies>
+               <dependencies>
                     <dependency>
-                        <groupId>com.google.code.maven-scm-provider-svnjava</groupId>
-                        <artifactId>maven-scm-provider-svnjava</artifactId>
-                        <version>${maven.scm.provider.version}</version>
+                        <groupId>org.apache.maven.scm</groupId>
+                        <artifactId>maven-scm-provider-gitexe</artifactId>
+                        <version>1.8.1</version>
                     </dependency>
                 </dependencies>
-                <configuration>
-                    <tagNameFormat>@{project.artifactId}-@{project.version}</tagNameFormat>
-                    <autoVersionSubmodules>true</autoVersionSubmodules>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>eu.europa.ec.fisheries.uvms.reporting</groupId>
     <artifactId>reporting</artifactId>
-    <version>1.0.3-SNAPSHOT</version>
+    <version>1.0.3</version>
     <packaging>pom</packaging>
     <description>Maven projekt-archetype for UnionVms modules</description>
     <url>http://www.your.site.com/</url>
@@ -48,7 +47,7 @@
 
     <scm>
         <connection>${scm.connection}</connection>
-        <tag>HEAD</tag>
+        <tag>reporting-1.0.3</tag>
     </scm>
 
     <distributionManagement>

--- a/rest/pom.xml
+++ b/rest/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>eu.europa.ec.fisheries.uvms.reporting</groupId>
         <artifactId>reporting</artifactId>
-        <version>1.0.4</version>
+        <version>1.0.5-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/rest/pom.xml
+++ b/rest/pom.xml
@@ -14,6 +14,12 @@
     <dependencies>
 
         <dependency>
+			<groupId>fish.focus.uvms.maven</groupId>
+			<artifactId>uvms-pom-monitoring-deps</artifactId>
+			<type>pom</type>
+		</dependency>
+
+        <dependency>
             <groupId>eu.europa.ec.fisheries.uvms</groupId>
             <artifactId>usm4uvms</artifactId>
         </dependency>
@@ -119,7 +125,7 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>3.6.2</version>
+            <version>2.8.0</version>
             <scope>test</scope>
         </dependency>
 

--- a/rest/pom.xml
+++ b/rest/pom.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <artifactId>rest</artifactId>
     <name>${project.parent.artifactId}-rest</name>
@@ -9,7 +8,7 @@
     <parent>
         <groupId>eu.europa.ec.fisheries.uvms.reporting</groupId>
         <artifactId>reporting</artifactId>
-        <version>1.0.3-SNAPSHOT</version>
+        <version>1.0.3</version>
     </parent>
 
     <dependencies>

--- a/rest/pom.xml
+++ b/rest/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>eu.europa.ec.fisheries.uvms.reporting</groupId>
         <artifactId>reporting</artifactId>
-        <version>1.0.4-SNAPSHOT</version>
+        <version>1.0.4</version>
     </parent>
 
     <dependencies>

--- a/rest/pom.xml
+++ b/rest/pom.xml
@@ -154,17 +154,7 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.1</version>
-                <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>2.4</version>
                 <executions>
                     <execution>
                         <id>wildfly</id>

--- a/rest/pom.xml
+++ b/rest/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>eu.europa.ec.fisheries.uvms.reporting</groupId>
         <artifactId>reporting</artifactId>
-        <version>1.0.3</version>
+        <version>1.0.4-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/rest/src/main/webapp/WEB-INF/web.xml
+++ b/rest/src/main/webapp/WEB-INF/web.xml
@@ -1,6 +1,42 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <web-app xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://xmlns.jcp.org/xml/ns/javaee" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd" version="3.1">
 
+    <context-param>
+        <param-name>javamelody.datasources</param-name>
+        <param-value>java:jboss/datasources/uvms_reporting</param-value>
+    </context-param>
+	<listener>
+		<listener-class>net.bull.javamelody.SessionListener</listener-class>
+	</listener>        
+	<filter>
+		<filter-name>javamelody</filter-name>
+		<filter-class>net.bull.javamelody.MonitoringFilter</filter-class>
+		<async-supported>true</async-supported>
+		<init-param>
+			<param-name>displayed-counters</param-name>
+			<param-value>http,sql,ejb,error,log</param-value>
+		</init-param>
+		<init-param>
+			<param-name>system-actions-enabled</param-name>
+			<param-value>true</param-value>
+		</init-param>
+		<init-param>
+			<param-name>storage-directory</param-name>
+			<param-value>javamelody-reporting</param-value>
+		</init-param>
+		<init-param>
+			<param-name>datasources</param-name>
+			<param-value>java:jboss/datasources/uvms_reporting</param-value>
+		</init-param>						
+	</filter>
+	<filter-mapping>
+		<filter-name>javamelody</filter-name>
+		<url-pattern>/*</url-pattern>
+		<dispatcher>REQUEST</dispatcher>
+		<dispatcher>ASYNC</dispatcher>
+	</filter-mapping>
+
+
 	<filter-mapping>
 		<filter-name>AuthenticationFilter</filter-name>
 		<url-pattern>/rest/report/*</url-pattern>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>eu.europa.ec.fisheries.uvms.reporting</groupId>
         <artifactId>reporting</artifactId>
-        <version>1.0.4</version>
+        <version>1.0.5-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -15,6 +15,12 @@
     <dependencies>
 
         <dependency>
+			<groupId>fish.focus.uvms.maven</groupId>
+			<artifactId>uvms-pom-monitoring-deps</artifactId>
+			<type>pom</type>
+		</dependency>
+
+        <dependency>
             <groupId>eu.europa.ec.fisheries.uvms.activity</groupId>
             <artifactId>activity-model</artifactId>
         </dependency>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>eu.europa.ec.fisheries.uvms.reporting</groupId>
         <artifactId>reporting</artifactId>
-        <version>1.0.4-SNAPSHOT</version>
+        <version>1.0.4</version>
     </parent>
 
     <dependencies>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>eu.europa.ec.fisheries.uvms.movement</groupId>
             <artifactId>movement-model</artifactId>
-            <classifier>xmlgregoriancalendar</classifier>
+            <classifier>date</classifier>
         </dependency>
 
         <dependency>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>service</artifactId>
@@ -10,7 +9,7 @@
     <parent>
         <groupId>eu.europa.ec.fisheries.uvms.reporting</groupId>
         <artifactId>reporting</artifactId>
-        <version>1.0.3-SNAPSHOT</version>
+        <version>1.0.3</version>
     </parent>
 
     <dependencies>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>eu.europa.ec.fisheries.uvms.reporting</groupId>
         <artifactId>reporting</artifactId>
-        <version>1.0.3</version>
+        <version>1.0.4-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/reporting/service/bean/impl/ReportExecutionServiceBean.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/reporting/service/bean/impl/ReportExecutionServiceBean.java
@@ -228,7 +228,7 @@ public class ReportExecutionServiceBean implements ReportExecutionService {
             for (MovementMapResponseType map : movementMap) {
                 for (MovementType movement : map.getMovements()) {
                     if (movement.getPositionTime() != null) {
-                        Date movementDate = movement.getPositionTime().toGregorianCalendar().getTime();
+                        Date movementDate = movement.getPositionTime();
                         if (movementDate.after(trip.getRelativeFirstFaDateTime()) && movementDate.before(trip.getRelativeLastFaDateTime())) {
                             count++;
                         }

--- a/service/src/main/java/eu/europa/ec/fisheries/uvms/reporting/service/dto/MovementDTO.java
+++ b/service/src/main/java/eu/europa/ec/fisheries/uvms/reporting/service/dto/MovementDTO.java
@@ -34,6 +34,8 @@ import javax.xml.datatype.XMLGregorianCalendar;
 
 import static javax.measure.unit.NonSI.*;
 
+import java.util.Date;
+
 public class MovementDTO {
 
     public static final SimpleFeatureType SIMPLE_FEATURE_TYPE = buildFeatureType();
@@ -123,7 +125,7 @@ public class MovementDTO {
         String getConnectId();
         String getStatus();
         Double getCalculatedSpeed();
-        XMLGregorianCalendar getPositionTime();
+        Date getPositionTime();
         Double getReportedSpeed();
         MovementActivityType getActivity();
         Double getReportedCourse();

--- a/service/src/main/resources/META-INF/ejb-jar.xml
+++ b/service/src/main/resources/META-INF/ejb-jar.xml
@@ -1,0 +1,58 @@
+<ejb-jar
+	xmlns = "http://java.sun.com/xml/ns/javaee"
+	version = "3.1"
+	xmlns:xsi = "http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation = "http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/ejb-jar_3_1.xsd">
+	<interceptors>
+		<interceptor>
+			<interceptor-class>net.bull.javamelody.MonitoringInterceptor</interceptor-class>
+		</interceptor>
+	</interceptors>
+	
+	<assembly-descriptor>
+		<interceptor-binding>
+			<ejb-name>ActivityServiceBean</ejb-name>
+			<interceptor-class>net.bull.javamelody.MonitoringInterceptor</interceptor-class>
+		</interceptor-binding>
+		<interceptor-binding>
+			<ejb-name>AlarmServiceBean</ejb-name>
+			<interceptor-class>net.bull.javamelody.MonitoringInterceptor</interceptor-class>
+		</interceptor-binding>
+		<interceptor-binding>
+			<ejb-name>AssetServiceBean</ejb-name>
+			<interceptor-class>net.bull.javamelody.MonitoringInterceptor</interceptor-class>
+		</interceptor-binding>
+		<interceptor-binding>
+			<ejb-name>AuditServiceBean</ejb-name>
+			<interceptor-class>net.bull.javamelody.MonitoringInterceptor</interceptor-class>
+		</interceptor-binding>
+		<interceptor-binding>
+			<ejb-name>MovementServiceBean</ejb-name>
+			<interceptor-class>net.bull.javamelody.MonitoringInterceptor</interceptor-class>
+		</interceptor-binding>
+		<interceptor-binding>
+			<ejb-name>ReportEventServiceBean</ejb-name>
+			<interceptor-class>net.bull.javamelody.MonitoringInterceptor</interceptor-class>
+		</interceptor-binding>
+		<interceptor-binding>
+			<ejb-name>ReportExecutionServiceBean</ejb-name>
+			<interceptor-class>net.bull.javamelody.MonitoringInterceptor</interceptor-class>
+		</interceptor-binding>
+		<interceptor-binding>
+			<ejb-name>ReportRepositoryBean</ejb-name>
+			<interceptor-class>net.bull.javamelody.MonitoringInterceptor</interceptor-class>
+		</interceptor-binding>
+		<interceptor-binding>
+			<ejb-name>ReportServiceBean</ejb-name>
+			<interceptor-class>net.bull.javamelody.MonitoringInterceptor</interceptor-class>
+		</interceptor-binding>
+		<interceptor-binding>
+			<ejb-name>RulesEventServiceBean</ejb-name>
+			<interceptor-class>net.bull.javamelody.MonitoringInterceptor</interceptor-class>
+		</interceptor-binding>
+		<interceptor-binding>
+			<ejb-name>SpatialServiceBean</ejb-name>
+			<interceptor-class>net.bull.javamelody.MonitoringInterceptor</interceptor-class>
+		</interceptor-binding>		
+	</assembly-descriptor>
+</ejb-jar>


### PR DESCRIPTION
Add metrics (javamelody).  Moved versions assertj to remove dependency on jdk8. Update usm4uvms and uvms-commons.