### PR TITLE
Fix jdk8 add metrics remove provided from ear

### DIFF
--- a/deploy-weblogic/pom.xml
+++ b/deploy-weblogic/pom.xml
@@ -62,7 +62,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-ear-plugin</artifactId>
-                <version>2.7</version>
                 <configuration>
                     <defaultLibBundleDir>APP-INF/lib</defaultLibBundleDir>
                     <skinnyWars>true</skinnyWars>
@@ -100,6 +99,7 @@
                             <bundleDir>/</bundleDir>
                         </jarModule>
                     </modules>
+                    <version>7</version>
                 </configuration>
             </plugin>
         </plugins>

--- a/deploy-weblogic/pom.xml
+++ b/deploy-weblogic/pom.xml
@@ -99,7 +99,6 @@
                             <bundleDir>/</bundleDir>
                         </jarModule>
                     </modules>
-                    <version>7</version>
                 </configuration>
             </plugin>
         </plugins>

--- a/deploy-wildfly/pom.xml
+++ b/deploy-wildfly/pom.xml
@@ -40,7 +40,6 @@
                         </webModule>
                     </modules>
                     <skinnyWars>true</skinnyWars>
-                    <version>7</version>
                 </configuration>
             </plugin>
             <plugin>

--- a/deploy-wildfly/pom.xml
+++ b/deploy-wildfly/pom.xml
@@ -19,7 +19,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-ear-plugin</artifactId>
-                <version>2.7</version>
                 <configuration>
                     <modules>
                         <ejbModule>
@@ -41,6 +40,7 @@
                         </webModule>
                     </modules>
                     <skinnyWars>true</skinnyWars>
+                    <version>7</version>
                 </configuration>
             </plugin>
             <plugin>

--- a/message/pom.xml
+++ b/message/pom.xml
@@ -43,6 +43,12 @@
         </dependency>
 
         <dependency>
+			<groupId>fish.focus.uvms.maven</groupId>
+			<artifactId>uvms-pom-monitoring-deps</artifactId>
+			<type>pom</type>
+		</dependency>
+
+        <dependency>
             <groupId>eu.europa.ec.fisheries.uvms</groupId>
             <artifactId>uvms-commons</artifactId>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -36,11 +36,11 @@
         <application.version>${project.parent.version}</application.version>
         <application.logfile>/app/logs/${project.parent.artifactId}/${project.parent.artifactId}.log</application.logfile>
         <application.error.logfile>/app/logs/${project.parent.artifactId}/${project.parent.artifactId}-error.log</application.error.logfile>
-        <hibernate.version>4.3.10.Final</hibernate.version>
-        <uvms.commons.version>2.0.25</uvms.commons.version>
-        <geotools.version>14-M1</geotools.version>
-        <lombok.version>1.16.4</lombok.version>
-        <usm4uvms.version>3.0.6</usm4uvms.version>
+        <hibernate.version>4.3.11.Final</hibernate.version>
+        <uvms.commons.version>2.0.27</uvms.commons.version>
+        <geotools.version>14.4</geotools.version>
+        <lombok.version>1.16.18</lombok.version>
+        <usm4uvms.version>3.0.8</usm4uvms.version>
         <maven.release.plugin.version>2.5.3</maven.release.plugin.version>
         <maven.scm.provider.version>2.1.1</maven.scm.provider.version>
         <rules.model.version>3.0.7</rules.model.version>
@@ -72,6 +72,13 @@
     <dependencyManagement>
 
         <dependencies>
+
+			<dependency>
+				<groupId>fish.focus.uvms.maven</groupId>
+				<artifactId>uvms-pom-monitoring-deps</artifactId>
+				<version>1.8</version>
+				<type>pom</type>
+			</dependency>
 
             <dependency>
                 <groupId>eu.europa.ec.fisheries.uvms.activity</groupId>
@@ -239,13 +246,13 @@
             <dependency>
                 <groupId>org.projectlombok</groupId>
                 <artifactId>lombok</artifactId>
-                <version>1.16.4</version>
+                <version>1.16.18</version>
             </dependency>
 
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>18.0</version>
+                <version>20.0</version>
             </dependency>
 
             <dependency>

--- a/rest/pom.xml
+++ b/rest/pom.xml
@@ -14,6 +14,12 @@
     <dependencies>
 
         <dependency>
+			<groupId>fish.focus.uvms.maven</groupId>
+			<artifactId>uvms-pom-monitoring-deps</artifactId>
+			<type>pom</type>
+		</dependency>
+
+        <dependency>
             <groupId>eu.europa.ec.fisheries.uvms</groupId>
             <artifactId>usm4uvms</artifactId>
         </dependency>
@@ -119,7 +125,7 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>3.6.2</version>
+            <version>2.8.0</version>
             <scope>test</scope>
         </dependency>
 

--- a/rest/src/main/webapp/WEB-INF/web.xml
+++ b/rest/src/main/webapp/WEB-INF/web.xml
@@ -1,6 +1,42 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <web-app xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://xmlns.jcp.org/xml/ns/javaee" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd" version="3.1">
 
+    <context-param>
+        <param-name>javamelody.datasources</param-name>
+        <param-value>java:jboss/datasources/uvms_reporting</param-value>
+    </context-param>
+	<listener>
+		<listener-class>net.bull.javamelody.SessionListener</listener-class>
+	</listener>        
+	<filter>
+		<filter-name>javamelody</filter-name>
+		<filter-class>net.bull.javamelody.MonitoringFilter</filter-class>
+		<async-supported>true</async-supported>
+		<init-param>
+			<param-name>displayed-counters</param-name>
+			<param-value>http,sql,ejb,error,log</param-value>
+		</init-param>
+		<init-param>
+			<param-name>system-actions-enabled</param-name>
+			<param-value>true</param-value>
+		</init-param>
+		<init-param>
+			<param-name>storage-directory</param-name>
+			<param-value>javamelody-reporting</param-value>
+		</init-param>
+		<init-param>
+			<param-name>datasources</param-name>
+			<param-value>java:jboss/datasources/uvms_reporting</param-value>
+		</init-param>						
+	</filter>
+	<filter-mapping>
+		<filter-name>javamelody</filter-name>
+		<url-pattern>/*</url-pattern>
+		<dispatcher>REQUEST</dispatcher>
+		<dispatcher>ASYNC</dispatcher>
+	</filter-mapping>
+
+
 	<filter-mapping>
 		<filter-name>AuthenticationFilter</filter-name>
 		<url-pattern>/rest/report/*</url-pattern>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -15,6 +15,12 @@
     <dependencies>
 
         <dependency>
+			<groupId>fish.focus.uvms.maven</groupId>
+			<artifactId>uvms-pom-monitoring-deps</artifactId>
+			<type>pom</type>
+		</dependency>
+
+        <dependency>
             <groupId>eu.europa.ec.fisheries.uvms.activity</groupId>
             <artifactId>activity-model</artifactId>
         </dependency>

--- a/service/src/main/resources/META-INF/ejb-jar.xml
+++ b/service/src/main/resources/META-INF/ejb-jar.xml
@@ -1,0 +1,58 @@
+<ejb-jar
+	xmlns = "http://java.sun.com/xml/ns/javaee"
+	version = "3.1"
+	xmlns:xsi = "http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation = "http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/ejb-jar_3_1.xsd">
+	<interceptors>
+		<interceptor>
+			<interceptor-class>net.bull.javamelody.MonitoringInterceptor</interceptor-class>
+		</interceptor>
+	</interceptors>
+	
+	<assembly-descriptor>
+		<interceptor-binding>
+			<ejb-name>ActivityServiceBean</ejb-name>
+			<interceptor-class>net.bull.javamelody.MonitoringInterceptor</interceptor-class>
+		</interceptor-binding>
+		<interceptor-binding>
+			<ejb-name>AlarmServiceBean</ejb-name>
+			<interceptor-class>net.bull.javamelody.MonitoringInterceptor</interceptor-class>
+		</interceptor-binding>
+		<interceptor-binding>
+			<ejb-name>AssetServiceBean</ejb-name>
+			<interceptor-class>net.bull.javamelody.MonitoringInterceptor</interceptor-class>
+		</interceptor-binding>
+		<interceptor-binding>
+			<ejb-name>AuditServiceBean</ejb-name>
+			<interceptor-class>net.bull.javamelody.MonitoringInterceptor</interceptor-class>
+		</interceptor-binding>
+		<interceptor-binding>
+			<ejb-name>MovementServiceBean</ejb-name>
+			<interceptor-class>net.bull.javamelody.MonitoringInterceptor</interceptor-class>
+		</interceptor-binding>
+		<interceptor-binding>
+			<ejb-name>ReportEventServiceBean</ejb-name>
+			<interceptor-class>net.bull.javamelody.MonitoringInterceptor</interceptor-class>
+		</interceptor-binding>
+		<interceptor-binding>
+			<ejb-name>ReportExecutionServiceBean</ejb-name>
+			<interceptor-class>net.bull.javamelody.MonitoringInterceptor</interceptor-class>
+		</interceptor-binding>
+		<interceptor-binding>
+			<ejb-name>ReportRepositoryBean</ejb-name>
+			<interceptor-class>net.bull.javamelody.MonitoringInterceptor</interceptor-class>
+		</interceptor-binding>
+		<interceptor-binding>
+			<ejb-name>ReportServiceBean</ejb-name>
+			<interceptor-class>net.bull.javamelody.MonitoringInterceptor</interceptor-class>
+		</interceptor-binding>
+		<interceptor-binding>
+			<ejb-name>RulesEventServiceBean</ejb-name>
+			<interceptor-class>net.bull.javamelody.MonitoringInterceptor</interceptor-class>
+		</interceptor-binding>
+		<interceptor-binding>
+			<ejb-name>SpatialServiceBean</ejb-name>
+			<interceptor-class>net.bull.javamelody.MonitoringInterceptor</interceptor-class>
+		</interceptor-binding>		
+	</assembly-descriptor>
+</ejb-jar>


### PR DESCRIPTION
Add metrics (javamelody). Moved versions assertj to remove dependency on jdk8. Update usm4uvms and uvms-commons.