### PR TITLE
introduce property ${hibernate.spatial.dialect} for spatial dialect,

### DIFF
--- a/service/src/main/resources/META-INF/persistence.xml
+++ b/service/src/main/resources/META-INF/persistence.xml
@@ -7,7 +7,7 @@
     <persistence-unit name="reportingPUposgres" transaction-type="JTA">
         <jta-data-source>java:jboss/datasources/uvms_reporting</jta-data-source>
         <properties>
-            <property name="hibernate.dialect" value="org.hibernate.spatial.dialect.postgis.PostgisDialect"/>
+            <property name="hibernate.dialect" value="${hibernate.spatial.dialect}"/>
             <property name="show_sql" value="false" />
             <property name="hibernate.default_schema" value="reporting"/>
             <property name="hibernate.id.optimizer.pooled.preferred" value="NONE"/>


### PR DESCRIPTION
default value now set to <property name="hibernate.spatial.dialect"
value="org.hibernate.spatial.dialect.postgis.PostgisDialect"/>  in
https://github.com/UnionVMS/UVMS-Docker/blob/dev/wildfly-base/src/main/docker/standalone-uvms.xml